### PR TITLE
Fixing a crash when opening a file in a large folder, and resolving a perf issue with the thumbs bar

### DIFF
--- a/include/ui/ui_core.h
+++ b/include/ui/ui_core.h
@@ -300,28 +300,22 @@ struct UI_Block_Data {
 	u32	 hash;
 };
 
-struct UI_string_array {
-	char *buffer;
-	u32 capacity;
-	u32 count;
-};
-
 struct UI_Hit_Test_Item {
 	u32 hash;
 	u32 depth_level;
 };
 struct UI_Context {
-	u32							buffer_index;
-	Dynarray <UI_Block>         buffers[2];
-    Dynarray <UI_Block*>        parents;
-    Dynarray <u32>              hashes;
-	Dynarray <UI_Block_Data>	data_chunks;
-	Dynarray <UI_Hit_Test_Item> blocks_hit_test;
+	u32									buffer_index;
+	StableDynarray <UI_Block>       	buffers[2];
+    StableDynarray <UI_Block*>      	parents;
+    StableDynarray <u32>            	hashes;
+	StableDynarray <UI_Block_Data>		data_chunks;
+	StableDynarray <UI_Hit_Test_Item> 	blocks_hit_test;
 
 	UI_Hit_Test_Item			hit_test_result;
 
     FT_Library                  ft_lib;
-	UI_string_array				strings;
+	StableDynarray<char>		strings;
 
     bool                        textures[UI_MAX_TEXTURES];
     Dynarray <UI_Font>          fonts;  

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -3024,6 +3024,8 @@ static void update_gui() {
 					int thumbs_that_fit = (WW / thumb_dim) + 2;
 					int start_index = G->current_file_index - (min(G->current_file_index, thumbs_that_fit / 2));
 					f32 offset_begin = begin + start_index * thumb_dim;
+					int end_index = min(start_index + thumbs_that_fit, G->files.Count);
+
 					UI_Block *thumbs_scroll = UI_push_block(ctx);
 					thumbs_scroll->style.position[axis_x] = { UI_Position_t::absolute, f32(offset_begin) };
 					thumbs_scroll->style.layout.axis = axis_x;
@@ -3032,7 +3034,7 @@ static void update_gui() {
 					UI_push_parent_defer(ctx, thumbs_scroll)
 					{
 						UI_push_hash(ctx, UI_hash_djb2(ctx, "thumbs"));
-						for (int i = start_index; i < start_index+thumbs_that_fit; i++) {
+						for (int i = start_index; i < end_index; i++) {
 							UI_Button_Style thumb_style;
 							thumb_style.color_bg.base = theme->bg_main_2;
 							thumb_style.color_bg.hot = theme->bg_main_3;

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -3017,18 +3017,22 @@ static void update_gui() {
 				UI_push_parent_defer(ctx, thumbs_bar)
 				{
 					static f32 begin = 0;
-					f32 begin_should = WW / 2.f - thumb_dim / 2.f - G->current_file_index * thumb_dim + 25.f;
+					f32 begin_should = WW / 2.f - thumb_dim / 2.f - G->current_file_index * thumb_dim + (thumb_dim / 2.f);
 					if (WW)
 						begin = UI_lerp_f32(begin, begin_should, 0.2);
+
+					int thumbs_that_fit = (WW / thumb_dim) + 2;
+					int start_index = G->current_file_index - (min(G->current_file_index, thumbs_that_fit / 2));
+					f32 offset_begin = begin + start_index * thumb_dim;
 					UI_Block *thumbs_scroll = UI_push_block(ctx);
-					thumbs_scroll->style.position[axis_x] = { UI_Position_t::absolute, f32(begin) };
+					thumbs_scroll->style.position[axis_x] = { UI_Position_t::absolute, f32(offset_begin) };
 					thumbs_scroll->style.layout.axis = axis_x;
 					thumbs_bar->style.color[c_background] = theme->bg_sub;
 					thumbs_bar->flags |= UI_Block_Flags_draw_background;
 					UI_push_parent_defer(ctx, thumbs_scroll)
 					{
 						UI_push_hash(ctx, UI_hash_djb2(ctx, "thumbs"));
-						for (int i = 0; i < G->files.Count; i++) {
+						for (int i = start_index; i < start_index+thumbs_that_fit; i++) {
 							UI_Button_Style thumb_style;
 							thumb_style.color_bg.base = theme->bg_main_2;
 							thumb_style.color_bg.hot = theme->bg_main_3;


### PR DESCRIPTION
Resolves #44 

I've added a new type called StableDynarray that uses VirtualAlloc to reserve a large block of memory so that the arrays can grow without moving the array, which causes a crash. This is kind of a halfway step towards using actual arenas. I saw the todo comment to move to arenas, but that seemed like a larger change.

I'm not sure what the policy is for platform specific stuff, so I can move the VirtualAlloc calls out to a separate file if desired.

I also changed the thumbs bar to only render the thumbs that are currently visible on screen. When there are a lot of files in the directory, adding the UI buttons for all of them really tanks perf.